### PR TITLE
fix: corrige pipeline de deploy travado (terraform + build do worker)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -40,6 +40,12 @@ jobs:
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/api/main.go
           zip deployment.zip bootstrap
 
+      - name: Build Worker Lambda
+        run: |
+          rm -f bootstrap
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/worker/main.go
+          zip deployment-worker.zip bootstrap
+
       - name: Terraform Init
         working-directory: terraform/environments/dev
         run: terraform init -input=false

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: terraform/environments/dev
-        run: terraform init
+        run: terraform init -input=false
 
       - name: Terraform Plan
         working-directory: terraform/environments/dev
@@ -50,7 +50,8 @@ jobs:
           TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           TF_VAR_stripe_secret_key: ${{ secrets.STRIPE_SECRET_KEY }}
           TF_VAR_stripe_webhook_secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-        run: terraform plan -out=tfplan
+          TF_VAR_revenuecat_webhook_secret: ${{ secrets.REVENUECAT_WEBHOOK_SECRET }}
+        run: terraform plan -input=false -out=tfplan
 
       - name: Terraform Apply
         working-directory: terraform/environments/dev
@@ -58,6 +59,7 @@ jobs:
           TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           TF_VAR_stripe_secret_key: ${{ secrets.STRIPE_SECRET_KEY }}
           TF_VAR_stripe_webhook_secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          TF_VAR_revenuecat_webhook_secret: ${{ secrets.REVENUECAT_WEBHOOK_SECRET }}
         run: terraform apply -auto-approve tfplan
 
       - name: Get API Endpoint

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Terraform Init
         working-directory: terraform/environments/prod
-        run: terraform init
+        run: terraform init -input=false
 
       - name: Terraform Plan
         working-directory: terraform/environments/prod
@@ -51,7 +51,8 @@ jobs:
           TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           TF_VAR_stripe_secret_key: ${{ secrets.STRIPE_SECRET_KEY }}
           TF_VAR_stripe_webhook_secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-        run: terraform plan -out=tfplan
+          TF_VAR_revenuecat_webhook_secret: ${{ secrets.REVENUECAT_WEBHOOK_SECRET }}
+        run: terraform plan -input=false -out=tfplan
 
       - name: Terraform Apply
         working-directory: terraform/environments/prod
@@ -59,6 +60,7 @@ jobs:
           TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           TF_VAR_stripe_secret_key: ${{ secrets.STRIPE_SECRET_KEY }}
           TF_VAR_stripe_webhook_secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          TF_VAR_revenuecat_webhook_secret: ${{ secrets.REVENUECAT_WEBHOOK_SECRET }}
         run: terraform apply -auto-approve tfplan
 
       - name: Get API Endpoint

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -41,6 +41,12 @@ jobs:
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/api/main.go
           zip deployment.zip bootstrap
 
+      - name: Build Worker Lambda
+        run: |
+          rm -f bootstrap
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/worker/main.go
+          zip deployment-worker.zip bootstrap
+
       - name: Terraform Init
         working-directory: terraform/environments/prod
         run: terraform init -input=false

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -35,7 +35,7 @@ jobs:
         id: init
         run: |
           cd terraform/environments/dev
-          terraform init
+          terraform init -input=false
 
       - name: Terraform Validate
         id: validate
@@ -48,7 +48,7 @@ jobs:
         id: plan
         run: |
           cd terraform/environments/dev
-          terraform plan -no-color \
+          terraform plan -no-color -input=false \
             -var="stripe_secret_key=${{ secrets.STRIPE_SECRET_KEY }}" \
             -var="stripe_webhook_secret=${{ secrets.STRIPE_WEBHOOK_SECRET }}" \
             -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'terraform/**'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   terraform-plan:
     name: Terraform Plan
@@ -13,6 +17,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -25,6 +34,17 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.16.0
+
+      - name: Build Lambda
+        run: |
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/api/main.go
+          zip deployment.zip bootstrap
+
+      - name: Build Worker Lambda
+        run: |
+          rm -f bootstrap
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/worker/main.go
+          zip deployment-worker.zip bootstrap
 
       - name: Terraform Format Check
         id: fmt
@@ -51,7 +71,8 @@ jobs:
           terraform plan -no-color -input=false \
             -var="stripe_secret_key=${{ secrets.STRIPE_SECRET_KEY }}" \
             -var="stripe_webhook_secret=${{ secrets.STRIPE_WEBHOOK_SECRET }}" \
-            -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}"
+            -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" \
+            -var="revenuecat_webhook_secret=${{ secrets.REVENUECAT_WEBHOOK_SECRET }}"
         continue-on-error: true
 
       - name: Comment PR

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -2,3 +2,8 @@ aws_region          = "us-east-1"
 environment         = "dev"
 app_name            = "applywise"
 dynamodb_table_name = "applywise-dev"
+
+# Price ID do Stripe não é sensível (é só um identificador público, não uma chave) —
+# pode ficar versionado. Sem isso o `terraform plan` trava esperando input interativo,
+# que nunca chega no GitHub Actions (achado ao reativar o pipeline de CI/CD).
+stripe_price_premium_monthly = "price_1U9DsjCgruCubp4jXMzIX9A7"

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -84,10 +84,11 @@ variable "optimization_queue_name" {
 variable "firebase_credentials_file" {
   description = "Path to Firebase service account JSON inside the Lambda package or layer"
   type        = string
+  default     = "/var/task/firebase_credentials.json"
 }
 
 variable "firebase_project_id" {
   description = "Firebase project ID (used to init FCM)"
   type        = string
-  default     = ""
+  default     = "applywise-35cc7"
 }

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -67,12 +67,13 @@ variable "optimization_queue_name" {
 variable "firebase_credentials_file" {
   description = "Path to Firebase service account JSON inside the Lambda package or layer"
   type        = string
+  default     = "/var/task/firebase_credentials.json"
 }
 
 variable "firebase_project_id" {
   description = "Firebase project ID (used to init FCM)"
   type        = string
-  default     = ""
+  default     = "applywise-35cc7"
 }
 
 variable "revenuecat_webhook_secret" {


### PR DESCRIPTION
## Summary
Continuação da PR #3 (que já corrigiu Terraform CLI + lint). Ao reativar o pipeline de verdade em dev, apareceram mais 3 problemas estruturais que nunca tinham sido pegos (o workflow nunca rodou de fato contra este código):

- `firebase_credentials_file` e `stripe_price_premium_monthly` (dev) sem valor obrigatório → `terraform plan` travava 17+ min esperando input interativo que nunca chega no GitHub Actions
- `firebase_project_id` e `revenuecat_webhook_secret` tinham default vazio que não batia com o valor real já rodando no Lambda — o primeiro apply via CI teria zerado essas duas variáveis silenciosamente (confirmado via `aws lambda get-function-configuration` antes/depois)
- `deployment-worker.zip` nunca era buildado no workflow (só a API) — `terraform plan` falhava com "no such file or directory" pro módulo do worker Lambda (SQS/otimização assíncrona)

Testado ao vivo em dev: `terraform apply` completo, sem drift nas variáveis, Lambda de dev confirmada com os valores corretos depois do apply.

**Pendência não resolvida (pré-existente, não uma regressão desta PR)**: nem o build da CI nem o `make build` local incluem `firebase_credentials.json` no zip — o arquivo não existe nem localmente nem como secret. Push via FCM continua quebrado (já documentado antes: o projeto Firebase referenciado em dev foi deletado).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J1WRgP7MA3inJKJQJxXe5m