### PR TITLE
fix: alinha Terraform de prod ao schema de billing atual (spec 007)

### DIFF
--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -50,21 +50,20 @@ module "lambda" {
   source_file   = "../../../deployment.zip"
 
   environment_variables = {
-    DYNAMODB_TABLE            = module.dynamodb.table_name
-    COGNITO_USER_POOL_ID      = module.cognito.user_pool_id
-    COGNITO_CLIENT_ID         = module.cognito.client_id
-    RESUMES_BUCKET_NAME       = module.s3.bucket_name
-    STRIPE_SECRET_KEY         = var.stripe_secret_key
-    STRIPE_WEBHOOK_SECRET     = var.stripe_webhook_secret
-    STRIPE_FREE_PRICE_ID      = var.stripe_free_price_id
-    STRIPE_PRO_PRICE_ID       = var.stripe_pro_price_id
-    OPENAI_API_KEY            = var.openai_api_key
-    SES_FROM_EMAIL            = var.ses_from_email
-    ENVIRONMENT               = var.environment
-    REVENUECAT_WEBHOOK_SECRET = var.revenuecat_webhook_secret
-    OPTIMIZATION_QUEUE_URL    = module.optimization_queue.queue_url
-    FIREBASE_CREDENTIALS_FILE = var.firebase_credentials_file
-    FIREBASE_PROJECT_ID       = var.firebase_project_id
+    DYNAMODB_TABLE               = module.dynamodb.table_name
+    COGNITO_USER_POOL_ID         = module.cognito.user_pool_id
+    COGNITO_CLIENT_ID            = module.cognito.client_id
+    RESUMES_BUCKET_NAME          = module.s3.bucket_name
+    STRIPE_SECRET_KEY            = var.stripe_secret_key
+    STRIPE_WEBHOOK_SECRET        = var.stripe_webhook_secret
+    STRIPE_PRICE_PREMIUM_MONTHLY = var.stripe_price_premium_monthly
+    OPENAI_API_KEY               = var.openai_api_key
+    SES_FROM_EMAIL               = var.ses_from_email
+    ENVIRONMENT                  = var.environment
+    REVENUECAT_WEBHOOK_SECRET    = var.revenuecat_webhook_secret
+    OPTIMIZATION_QUEUE_URL       = module.optimization_queue.queue_url
+    FIREBASE_CREDENTIALS_FILE    = var.firebase_credentials_file
+    FIREBASE_PROJECT_ID          = var.firebase_project_id
   }
 
   dynamodb_table_arn        = module.dynamodb.table_arn
@@ -80,7 +79,7 @@ module "lambda" {
 module "lambda_worker" {
   source = "../../modules/lambda"
 
-  environment   = var.environment
+  environment    = var.environment
   function_name  = "${var.app_name}-worker"
   handler        = "bootstrap"
   runtime        = "provided.al2"
@@ -88,10 +87,10 @@ module "lambda_worker" {
   lambda_timeout = 120
 
   environment_variables = {
-    DYNAMODB_TABLE         = module.dynamodb.table_name
-    OPENAI_API_KEY         = var.openai_api_key
-    ENVIRONMENT            = var.environment
-    OPTIMIZATION_QUEUE_URL = module.optimization_queue.queue_url
+    DYNAMODB_TABLE            = module.dynamodb.table_name
+    OPENAI_API_KEY            = var.openai_api_key
+    ENVIRONMENT               = var.environment
+    OPTIMIZATION_QUEUE_URL    = module.optimization_queue.queue_url
     FIREBASE_CREDENTIALS_FILE = var.firebase_credentials_file
     FIREBASE_PROJECT_ID       = var.firebase_project_id
   }

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -2,3 +2,8 @@ aws_region          = "us-east-1"
 environment         = "prod"
 app_name            = "applywise"
 dynamodb_table_name = "applywise-prod"
+
+# Price ID não é sensível (identificador público, não uma chave). PLACEHOLDER: é o price
+# antigo do modelo Free/Pro (pré-spec-007) em modo teste — checkout Premium não funciona
+# de verdade em produção até o Stripe live ser configurado (ver pending_prod_stripe_launch_setup).
+stripe_price_premium_monthly = "price_1SsqGYLZ2WOLEJxZktW6EQqe"

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -40,16 +40,9 @@ variable "stripe_webhook_secret" {
   sensitive   = true
 }
 
-variable "stripe_free_price_id" {
-  description = "Stripe Free Plan Price ID"
+variable "stripe_price_premium_monthly" {
+  description = "Stripe Price ID do plano Premium (US$19,99/mês) — spec 007. Placeholder de teste até o Stripe live de produção ser configurado (ver .spec de billing)."
   type        = string
-  sensitive   = true
-}
-
-variable "stripe_pro_price_id" {
-  description = "Stripe Pro Plan Price ID"
-  type        = string
-  sensitive   = true
 }
 
 variable "ses_from_email" {


### PR DESCRIPTION
## Summary
Continuação das PRs #3/#4. `terraform/environments/prod` ainda estava no schema antigo de billing (Free/Pro, pré-spec-007) — `stripe_free_price_id`/`stripe_pro_price_id`, enquanto o código só lê `STRIPE_PRICE_PREMIUM_MONTHLY` desde a spec 007.

**Achado importante**: confirmei via `aws lambda get-function-configuration` que a Lambda de produção rodando agora tem `STRIPE_PRICE_PREMIUM_MONTHLY=null` — o checkout do plano Premium já está quebrado em produção, antes de qualquer coisa desta sessão. Só ficou visível ao tentar reativar o pipeline de deploy.

## O que essa PR faz
- Migra `terraform/environments/prod` pro mesmo schema do dev (`stripe_price_premium_monthly`)
- Usa um price ID de TESTE como placeholder (o antigo price do Pro) — não é sensível, é só um identificador
- **Não resolve o Stripe live de produção** — isso é uma decisão explícita: destravar o pipeline agora, Stripe live fica pra depois do lançamento real (precisa da secret key live, que só o usuário pode fornecer, mesmo padrão dos scripts `create-hirefy-premium-price.sh`/`create-stripe-webhook.sh`)

Testado localmente: `terraform plan` (sem secrets.tfvars, simulando CI) mostra exatamente a troca esperada de variável nas duas Lambdas (api + worker), sem nada destrutivo — as únicas outras mudanças são recursos de configuração do S3 (lifecycle/encryption/versioning) que o Terraform detectou como ausentes no state e vai recriar.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J1WRgP7MA3inJKJQJxXe5m