### PR TITLE
Spec 011 (auto-apply LinkedIn) + Spec 012 (entrevista focada em gaps)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -37,13 +37,13 @@ jobs:
 
       - name: Build Lambda
         run: |
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/api/main.go
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/api/main.go
           zip deployment.zip bootstrap
 
       - name: Build Worker Lambda
         run: |
           rm -f bootstrap
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/worker/main.go
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/worker/main.go
           zip deployment-worker.zip bootstrap
 
       - name: Terraform Init

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -37,13 +37,13 @@ jobs:
 
       - name: Build Lambda
         run: |
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/api/main.go
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/api/main.go
           zip deployment.zip bootstrap
 
       - name: Build Worker Lambda
         run: |
           rm -f bootstrap
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/worker/main.go
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags="-s -w" -o bootstrap cmd/worker/main.go
           zip deployment-worker.zip bootstrap
 
       - name: Terraform Format Check

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -85,6 +85,7 @@ func init() {
 	resumeService := appservice.NewResumeOptimizerService(resumeRepo, aiClient, subscriptionRepo, creditTransactionRepo, queuePublisher, jobRepo, fcmNotifier)
 	pipelineCoachService := appservice.NewPipelineCoachService(pipelineRepo, aiClient, subscriptionRepo, creditTransactionRepo)
 	interviewPracticeService := appservice.NewInterviewPracticeService(pipelineRepo, interviewRepo, resumeRepo, aiClient, subscriptionRepo, creditTransactionRepo)
+	applyAssistService := appservice.NewApplyAssistService(resumeRepo, subscriptionRepo, aiClient)
 
 	revenueCatService := appservice.NewRevenueCatService(
 		subscriptionRepo,
@@ -106,6 +107,7 @@ func init() {
 		fcmNotifier,
 		pipelineCoachService,
 		interviewPracticeService,
+		applyAssistService,
 	)
 
 	// Configura Lambda adapter
@@ -176,6 +178,7 @@ func runLocalServer() {
 	resumeService := appservice.NewResumeOptimizerService(resumeRepo, aiClient, subscriptionRepo, creditTransactionRepo, queuePublisher, jobRepo, fcmNotifier)
 	pipelineCoachSvc := appservice.NewPipelineCoachService(pipelineRepo, aiClient, subscriptionRepo, creditTransactionRepo)
 	interviewPracticeSvc := appservice.NewInterviewPracticeService(pipelineRepo, interviewRepo, resumeRepo, aiClient, subscriptionRepo, creditTransactionRepo)
+	applyAssistSvc := appservice.NewApplyAssistService(resumeRepo, subscriptionRepo, aiClient)
 
 	router := httpAdapter.NewRouter(
 		authService,
@@ -190,6 +193,7 @@ func runLocalServer() {
 		fcmNotifier,
 		pipelineCoachSvc,
 		interviewPracticeSvc,
+		applyAssistSvc,
 	)
 
 	port := os.Getenv("PORT")

--- a/internal/adapters/inbound/http/handler/apply_assist_handler.go
+++ b/internal/adapters/inbound/http/handler/apply_assist_handler.go
@@ -1,0 +1,78 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/reangeline/backend_applywise/internal/adapters/inbound/http/middleware"
+	"github.com/reangeline/backend_applywise/internal/core/domain"
+	"github.com/reangeline/backend_applywise/internal/core/ports/inbound"
+	"github.com/reangeline/backend_applywise/pkg/security"
+)
+
+type ApplyAssistHandler struct {
+	applyAssistService inbound.ApplyAssistService
+}
+
+func NewApplyAssistHandler(applyAssistService inbound.ApplyAssistService) *ApplyAssistHandler {
+	return &ApplyAssistHandler{applyAssistService: applyAssistService}
+}
+
+type suggestAnswerRequestDTO struct {
+	ResumeID       string `json:"resume_id"`
+	JobTitle       string `json:"job_title"`
+	CompanyName    string `json:"company_name"`
+	JobDescription string `json:"job_description"`
+	Question       string `json:"question"`
+}
+
+func (h *ApplyAssistHandler) SuggestAnswer(w http.ResponseWriter, r *http.Request) {
+	userID, ok := r.Context().Value(middleware.UserIDContextKey).(string)
+	if !ok {
+		respondError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var body suggestAnswerRequestDTO
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		respondError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if body.ResumeID == "" || body.Question == "" {
+		respondError(w, http.StatusBadRequest, "resume_id and question are required")
+		return
+	}
+
+	result, err := h.applyAssistService.SuggestAnswer(r.Context(), inbound.SuggestAnswerRequest{
+		UserID:         userID,
+		ResumeID:       body.ResumeID,
+		JobTitle:       body.JobTitle,
+		CompanyName:    body.CompanyName,
+		JobDescription: body.JobDescription,
+		Question:       body.Question,
+	})
+	if err != nil {
+		respondApplyAssistError(w, err)
+		return
+	}
+
+	respondJSON(w, http.StatusOK, result)
+}
+
+func respondApplyAssistError(w http.ResponseWriter, err error) {
+	log.Printf("[apply-assist] error=%T: %v", err, err)
+	switch {
+	case errors.Is(err, domain.ErrResumeNotFound):
+		respondError(w, http.StatusNotFound, "resume not found")
+	case errors.Is(err, domain.ErrPremiumRequired):
+		respondError(w, http.StatusForbidden, "recurso exclusivo para assinantes Premium")
+	case errors.Is(err, domain.ErrSubscriptionNotFound):
+		respondError(w, http.StatusForbidden, "subscription not found")
+	case errors.Is(err, security.ErrInjectionDetected), errors.Is(err, security.ErrInputTooLong):
+		respondError(w, http.StatusBadRequest, err.Error())
+	default:
+		respondError(w, http.StatusInternalServerError, err.Error())
+	}
+}

--- a/internal/adapters/inbound/http/router.go
+++ b/internal/adapters/inbound/http/router.go
@@ -26,6 +26,7 @@ func NewRouter(
 	notifier outbound.NotificationPublisher,
 	pipelineCoachService inbound.PipelineCoachService,
 	interviewPracticeService inbound.InterviewPracticeService,
+	applyAssistService inbound.ApplyAssistService,
 ) *chi.Mux {
 	r := chi.NewRouter()
 
@@ -64,6 +65,7 @@ func NewRouter(
 	revenueCatWebhookHandler := handler.NewRevenueCatWebhookHandler(revenueCatService)
 	userHandler := handler.NewUserHandler(userService)
 	pipelineHandler := handler.NewPipelineHandler(pipelineRepo, contactRepo, userRepo, notifier, pipelineCoachService, interviewPracticeService)
+	applyAssistHandler := handler.NewApplyAssistHandler(applyAssistService)
 
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -139,6 +141,11 @@ func NewRouter(
 			r.Get("/pipeline/{jobId}/interview-practice", pipelineHandler.ListInterviewQuestions)
 			r.Post("/pipeline/{jobId}/interview-practice/question", pipelineHandler.NextInterviewQuestion)
 			r.Post("/pipeline/{jobId}/interview-practice/{questionId}/answer", pipelineHandler.SubmitInterviewAnswer)
+
+			// Apply-assist (spec 011) — assiste preenchimento de candidatura fora do produto
+			// (extensão de navegador). Não fica sob /pipeline/{jobId} porque acontece antes de
+			// a vaga existir no board (só é registrada depois que o usuário confirma o envio).
+			r.Post("/apply-assist/answer", applyAssistHandler.SuggestAnswer)
 		})
 	})
 

--- a/internal/adapters/outbound/ai/openai/ai_service_impl.go
+++ b/internal/adapters/outbound/ai/openai/ai_service_impl.go
@@ -860,6 +860,55 @@ Be honest — a rambling answer without a clear outcome should score low on cont
 	return result, nil
 }
 
+const applyAssistMaxTokens = 300
+
+func (s *aiServiceImpl) SuggestApplyAnswer(ctx context.Context, input *outbound.ApplyAssistAnswerInput) (*outbound.ApplyAssistAnswerResult, error) {
+	resumeJSON, _ := json.Marshal(input.ResumeData)
+
+	prompt := fmt.Sprintf(`You are helping a candidate fill out a job application screening question (e.g. LinkedIn Easy Apply custom question).
+
+Question: %s
+Target role: %s
+Company: %s
+Job description excerpt: %s
+Candidate's resume data (JSON): %s
+
+Suggest a short, honest, first-person answer based ONLY on the candidate's real resume data
+above — never invent experience, years, or skills the candidate doesn't have. If the
+question asks for a number (years of experience, salary expectation) and the resume doesn't
+give enough to infer it confidently, say so plainly instead of guessing. Keep it to 1-3
+sentences, ready to paste into a form field.
+
+Return ONLY a JSON object:
+{"suggested_answer": "the answer, first person, ready to use"}`,
+		input.Question, input.JobTitle, input.CompanyName,
+		truncate(input.JobDescription, 600), string(resumeJSON),
+	)
+
+	response, err := s.callOpenAI(ctx, defaultModel, prompt, 0.3, applyAssistMaxTokens)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw struct {
+		SuggestedAnswer string `json:"suggested_answer"`
+	}
+	if err := json.Unmarshal([]byte(response), &raw); err != nil {
+		clean := sanitizeJSON(response)
+		if clean == "" {
+			return nil, fmt.Errorf("failed to parse apply-assist answer: %w", err)
+		}
+		if err2 := json.Unmarshal([]byte(clean), &raw); err2 != nil {
+			return nil, fmt.Errorf("failed to parse apply-assist answer (cleaned): %w", err2)
+		}
+	}
+	if raw.SuggestedAnswer == "" {
+		return nil, fmt.Errorf("AI returned empty apply-assist answer")
+	}
+
+	return &outbound.ApplyAssistAnswerResult{SuggestedAnswer: raw.SuggestedAnswer}, nil
+}
+
 // truncate shortens a string to at most n runes.
 func truncate(s string, n int) string {
 	runes := []rune(s)

--- a/internal/adapters/outbound/ai/openai/ai_service_impl.go
+++ b/internal/adapters/outbound/ai/openai/ai_service_impl.go
@@ -19,7 +19,7 @@ const (
 	defaultModel              = "gpt-4.1-mini" // Parse, salary: cheap and fast
 	optimizationModel         = "gpt-4.1"      // Resume & LinkedIn optimization: higher quality
 	parseMaxTokens            = 800            // Sufficient for parse responses
-	optimizeMaxTokens         = 1800           // Large enough for full optimization JSON
+	optimizeMaxTokens         = 3500           // Full resume rewrite (all experiences/education/projects) + suggestions
 	linkedInMaxTokens         = 3200           // LinkedIn needs more tokens (longer about + suggestions)
 	defaultHTTPTimeout        = 90 * time.Second
 	perAttemptTimeout         = 25 * time.Second // regular calls

--- a/internal/adapters/outbound/ai/openai/ai_service_impl.go
+++ b/internal/adapters/outbound/ai/openai/ai_service_impl.go
@@ -724,6 +724,19 @@ func (s *aiServiceImpl) GenerateInterviewQuestion(ctx context.Context, input *ou
 		guidance = interviewKindGuidance[kind]
 	}
 
+	// Spec 012: quando existem gaps reais do currículo pra essa vaga (TargetGaps), a
+	// pergunta deve sondar de propósito um deles — não é mais um item de contexto passivo
+	// entre vários. Sem gaps (vaga nunca otimizada), mantém o comportamento genérico de
+	// sempre, sem essa instrução extra.
+	targetGapsInstruction := "No specific résumé gaps identified for this role yet — generate a well-rounded question for the target role."
+	if len(input.TargetGaps) > 0 {
+		targetGapsJSON, _ := json.Marshal(input.TargetGaps)
+		targetGapsInstruction = fmt.Sprintf(
+			"PRIORITIZE generating a question that probes one of these real gaps between the candidate's résumé and this job (pick one not already clearly covered by the questions already asked below): %s",
+			string(targetGapsJSON),
+		)
+	}
+
 	prompt := fmt.Sprintf(`You are a realistic interviewer for tech roles, helping a candidate practice for a real interview.
 
 Generate ONE %s interview question. %s
@@ -733,9 +746,9 @@ Target role: %s
 Company: %s
 Job description excerpt: %s
 Matched keywords/skills: %s
-Missing keywords/skills: %s
+%s
 Questions already asked in this practice session (do NOT repeat the theme): %s
-Weak spots from past answers in this session (probe these if relevant): %s
+Weak spots from past answers in this session (secondary signal — probe these if no uncovered target gap remains): %s
 
 Return ONLY a JSON object:
 {"question": "the interview question, in natural spoken English",
@@ -744,7 +757,7 @@ Return ONLY a JSON object:
 		kind, guidance, string(resumeJSON), input.JobTitle, input.CompanyName,
 		truncate(input.JobDescription, 600),
 		strings.Join(input.MatchedKeywords, ", "),
-		strings.Join(input.MissingKeywords, ", "),
+		targetGapsInstruction,
 		string(previousJSON), string(gapsJSON),
 	)
 

--- a/internal/application/service/apply_assist_service_impl.go
+++ b/internal/application/service/apply_assist_service_impl.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+
+	"github.com/reangeline/backend_applywise/internal/core/domain"
+	"github.com/reangeline/backend_applywise/internal/core/ports/inbound"
+	"github.com/reangeline/backend_applywise/internal/core/ports/outbound"
+	"github.com/reangeline/backend_applywise/pkg/security"
+)
+
+type applyAssistServiceImpl struct {
+	resumeRepo outbound.ResumeRepository
+	subRepo    outbound.SubscriptionRepository
+	aiService  outbound.AIService
+}
+
+func NewApplyAssistService(
+	resumeRepo outbound.ResumeRepository,
+	subRepo outbound.SubscriptionRepository,
+	aiService outbound.AIService,
+) inbound.ApplyAssistService {
+	return &applyAssistServiceImpl{
+		resumeRepo: resumeRepo,
+		subRepo:    subRepo,
+		aiService:  aiService,
+	}
+}
+
+func (s *applyAssistServiceImpl) SuggestAnswer(ctx context.Context, req inbound.SuggestAnswerRequest) (*inbound.SuggestAnswerResult, error) {
+	sub, err := s.subRepo.GetByUserID(ctx, req.UserID)
+	if err != nil {
+		return nil, err
+	}
+	if sub.Plan != domain.PlanPremium || !sub.IsActive() {
+		return nil, domain.ErrPremiumRequired
+	}
+
+	resume, err := s.resumeRepo.GetResume(ctx, req.UserID, req.ResumeID)
+	if err != nil {
+		return nil, err
+	}
+
+	question := security.SanitizeForPrompt(req.Question)
+	if err := security.ValidateShortField(question, "question"); err != nil {
+		return nil, err
+	}
+
+	jobTitle := security.SanitizeForPrompt(req.JobTitle)
+	if err := security.ValidateShortField(jobTitle, "job title"); err != nil {
+		return nil, err
+	}
+
+	companyName := security.SanitizeForPrompt(req.CompanyName)
+	if err := security.ValidateShortField(companyName, "company name"); err != nil {
+		return nil, err
+	}
+
+	jobDescription := security.SanitizeForPrompt(req.JobDescription)
+	if jobDescription != "" {
+		if err := security.ValidateJobDescription(jobDescription); err != nil {
+			return nil, err
+		}
+	}
+
+	result, err := s.aiService.SuggestApplyAnswer(ctx, &outbound.ApplyAssistAnswerInput{
+		Question:       question,
+		JobTitle:       jobTitle,
+		CompanyName:    companyName,
+		JobDescription: jobDescription,
+		ResumeData:     resume.ParsedData,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &inbound.SuggestAnswerResult{SuggestedAnswer: result.SuggestedAnswer}, nil
+}

--- a/internal/application/service/interview_practice_service_impl.go
+++ b/internal/application/service/interview_practice_service_impl.go
@@ -38,22 +38,31 @@ func NewInterviewPracticeService(
 	}
 }
 
-// resumeDataFor busca os dados estruturados do currículo ligado à vaga, se houver. Best
-// effort: uma vaga adicionada rápido (sem otimização) pode não ter currículo vinculado —
-// nesse caso a pergunta/avaliação seguem sem esses dados, só menos personalizadas.
-func (s *interviewPracticeServiceImpl) resumeDataFor(ctx context.Context, userID string, job *domain.PipelineJob) map[string]interface{} {
-	resumeID := job.OptimizedResumeID
-	if resumeID == "" {
-		resumeID = job.ResumeID
+// resumeDataFor busca os dados estruturados do currículo ligado à vaga, e os gaps mais
+// ricos (MissingRequirements, em frase) quando a vaga já passou por otimização — esses só
+// existem no OptimizedResume, não no PipelineJob. Best effort: uma vaga adicionada rápido
+// (sem otimização) pode não ter currículo vinculado — nesse caso a pergunta/avaliação
+// seguem sem esses dados, só menos personalizadas.
+//
+// Corrige um bug real: antes disso, a busca sempre usava GetResume mesmo quando
+// job.OptimizedResumeID estava setado — mas esse ID pertence à tabela de OptimizedResume,
+// não à de Resume, então ResumeData chegava vazio no prompt pra toda vaga já otimizada
+// (o erro era engolido silenciosamente).
+func (s *interviewPracticeServiceImpl) resumeDataFor(ctx context.Context, userID string, job *domain.PipelineJob) (map[string]interface{}, []string) {
+	if job.OptimizedResumeID != "" {
+		optimized, err := s.resumeRepo.GetOptimizedResume(ctx, userID, job.OptimizedResumeID)
+		if err == nil && optimized != nil {
+			return optimized.ParsedData, optimized.MissingRequirements
+		}
 	}
-	if resumeID == "" {
-		return nil
+	if job.ResumeID == "" {
+		return nil, nil
 	}
-	resume, err := s.resumeRepo.GetResume(ctx, userID, resumeID)
+	resume, err := s.resumeRepo.GetResume(ctx, userID, job.ResumeID)
 	if err != nil || resume == nil {
-		return nil
+		return nil, nil
 	}
-	return resume.ParsedData
+	return resume.ParsedData, nil
 }
 
 func (s *interviewPracticeServiceImpl) NextQuestion(ctx context.Context, req inbound.NextQuestionRequest) (*inbound.InterviewQuestionDTO, error) {
@@ -89,6 +98,14 @@ func (s *interviewPracticeServiceImpl) NextQuestion(ctx context.Context, req inb
 		pastGaps = append(pastGaps, h.Gaps...)
 	}
 
+	resumeData, missingRequirements := s.resumeDataFor(ctx, req.UserID, job)
+
+	// TargetGaps combina os dois sinais de gap real da vaga: MissingKeywords (palavras-chave
+	// soltas, sempre no PipelineJob) + MissingRequirements (a versão mais rica, em frase, só
+	// disponível quando a vaga passou por otimização) — sondar de propósito na entrevista,
+	// não é só contexto passivo (ver GenerateInterviewQuestion).
+	targetGaps := append(append([]string{}, job.MissingKeywords...), missingRequirements...)
+
 	result, err := s.aiService.GenerateInterviewQuestion(ctx, &outbound.InterviewQuestionInput{
 		Kind:              kind,
 		JobTitle:          job.JobTitle,
@@ -96,7 +113,8 @@ func (s *interviewPracticeServiceImpl) NextQuestion(ctx context.Context, req inb
 		JobDescription:    jobDescription,
 		MatchedKeywords:   job.MatchedKeywords,
 		MissingKeywords:   job.MissingKeywords,
-		ResumeData:        s.resumeDataFor(ctx, req.UserID, job),
+		TargetGaps:        targetGaps,
+		ResumeData:        resumeData,
 		PreviousQuestions: previousQuestions,
 		PastGaps:          pastGaps,
 	})
@@ -157,13 +175,14 @@ func (s *interviewPracticeServiceImpl) SubmitAnswer(ctx context.Context, req inb
 		}
 	}
 
+	resumeData, _ := s.resumeDataFor(ctx, req.UserID, job)
 	eval, err := s.aiService.EvaluateInterviewAnswer(ctx, &outbound.InterviewAnswerInput{
 		Kind:            string(question.Kind),
 		Question:        question.Question,
 		JobTitle:        job.JobTitle,
 		CompanyName:     job.CompanyName,
 		JobDescription:  jobDescription,
-		ResumeData:      s.resumeDataFor(ctx, req.UserID, job),
+		ResumeData:      resumeData,
 		CandidateAnswer: answer,
 	})
 	if err != nil {

--- a/internal/core/domain/erros.go
+++ b/internal/core/domain/erros.go
@@ -15,6 +15,7 @@ var (
 	ErrSubscriptionInactive        = errors.New("subscription is not active")
 	ErrInvalidPlan                 = errors.New("invalid subscription plan")
 	ErrInsufficientCredits         = errors.New("insufficient credits")
+	ErrPremiumRequired             = errors.New("premium subscription required")
 
 	// Resume errors
 	ErrResumeNotFound = errors.New("resume not found")

--- a/internal/core/ports/inbound/apply_assist_service.go
+++ b/internal/core/ports/inbound/apply_assist_service.go
@@ -1,0 +1,28 @@
+package inbound
+
+import "context"
+
+// SuggestAnswerRequest pede uma sugestão de resposta pra uma pergunta de triagem de
+// candidatura (ex: Easy Apply do LinkedIn), a partir de um currículo já salvo do usuário.
+// Não está ligado a uma vaga do pipeline — acontece antes de a vaga existir no board, já
+// que o registro no pipeline só ocorre depois que o usuário confirma o envio (spec 011).
+type SuggestAnswerRequest struct {
+	UserID         string
+	ResumeID       string
+	JobTitle       string
+	CompanyName    string
+	JobDescription string
+	Question       string
+}
+
+// SuggestAnswerResult é a resposta sugerida pela IA.
+type SuggestAnswerResult struct {
+	SuggestedAnswer string `json:"suggested_answer"`
+}
+
+// ApplyAssistService assiste o preenchimento de candidaturas fora do produto (ex: extensão
+// de navegador no LinkedIn). Feature exclusiva de assinantes Premium — sem consumo de
+// crédito (spec 011).
+type ApplyAssistService interface {
+	SuggestAnswer(ctx context.Context, req SuggestAnswerRequest) (*SuggestAnswerResult, error)
+}

--- a/internal/core/ports/outbound/ai_service.go
+++ b/internal/core/ports/outbound/ai_service.go
@@ -147,6 +147,21 @@ type InterviewAnswerResult struct {
 	FollowUp     string
 }
 
+// ApplyAssistAnswerInput holds the context needed to suggest an answer to an application
+// screening question (Easy Apply custom questions, e.g. "years of experience with X").
+type ApplyAssistAnswerInput struct {
+	Question       string
+	JobTitle       string
+	CompanyName    string
+	JobDescription string
+	ResumeData     map[string]interface{}
+}
+
+// ApplyAssistAnswerResult holds the AI-suggested answer.
+type ApplyAssistAnswerResult struct {
+	SuggestedAnswer string
+}
+
 // AIService define integração com serviço de IA
 type AIService interface {
 	ParseResume(ctx context.Context, content string) (*ResumeAnalysis, error)
@@ -158,4 +173,5 @@ type AIService interface {
 	GenerateCoachContent(ctx context.Context, input *CoachJobInput) (*CoachResult, error)
 	GenerateInterviewQuestion(ctx context.Context, input *InterviewQuestionInput) (*InterviewQuestionResult, error)
 	EvaluateInterviewAnswer(ctx context.Context, input *InterviewAnswerInput) (*InterviewAnswerResult, error)
+	SuggestApplyAnswer(ctx context.Context, input *ApplyAssistAnswerInput) (*ApplyAssistAnswerResult, error)
 }

--- a/internal/core/ports/outbound/ai_service.go
+++ b/internal/core/ports/outbound/ai_service.go
@@ -100,12 +100,16 @@ type CoachResult struct {
 
 // InterviewQuestionInput holds all context needed to generate a practice interview question.
 type InterviewQuestionInput struct {
-	Kind              string // "behavioral" | "technical" | "situational" | "screening"
-	JobTitle          string
-	CompanyName       string
-	JobDescription    string
-	MatchedKeywords   []string
-	MissingKeywords   []string
+	Kind            string // "behavioral" | "technical" | "situational" | "screening"
+	JobTitle        string
+	CompanyName     string
+	JobDescription  string
+	MatchedKeywords []string
+	MissingKeywords []string
+	// TargetGaps combina MissingKeywords (do PipelineJob) + MissingRequirements (do
+	// OptimizedResume, em frase) — gaps reais do currículo pra essa vaga específica, pra
+	// priorizar na geração da pergunta (spec 012), não é só contexto passivo.
+	TargetGaps        []string
 	ResumeData        map[string]interface{}
 	PreviousQuestions []string // pra não repetir tema
 	PastGaps          []string // gaps de respostas anteriores, pra mirar nos pontos fracos

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -48,7 +48,7 @@ variable "stripe_price_premium_monthly" {
 variable "web_app_base_url" {
   description = "Base URL do web-app, usada nas URLs de sucesso/cancelamento do Stripe Checkout"
   type        = string
-  default     = "http://localhost:3000"
+  default     = "https://hirefy-web-git-develop-reangelinehotmailcoms-projects.vercel.app"
 }
 
 variable "ses_from_email" {


### PR DESCRIPTION
## Summary
- Spec 011: endpoint `POST /apply-assist/answer` (sugestão de resposta via IA pra perguntas de triagem do Easy Apply), gate Premium sem consumo de crédito
- Spec 012: prática de entrevista prioriza sondar gaps reais do currículo pra vaga (MissingKeywords + MissingRequirements), corrige bug real de busca de currículo na tabela errada
- Fixes de infra acumulados: arquitetura Lambda dev (arm64), web_app_base_url, optimizeMaxTokens

## Test plan
- [x] Testado ao vivo em dev (extensão + web-app): apply-assist 403 com conta Free real, 200 com Premium
- [x] Testado ao vivo em dev: pergunta de entrevista sondando gap real (MAVI, 43% ATS) e fallback genérico (vaga sem otimização)
- [x] `go build ./...` e `go vet ./...` limpos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1WRgP7MA3inJKJQJxXe5m